### PR TITLE
Invalidate uploaded/deleted keys from memory

### DIFF
--- a/main.go
+++ b/main.go
@@ -17,7 +17,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-const version string = "0.9.0"
+const version string = "0.10.0"
 
 var (
 	host               string

--- a/tests/memory.bats
+++ b/tests/memory.bats
@@ -21,6 +21,12 @@ load helpers.sh
   [[ "$(SHA $DIR/blob)" == "$(SHA $TMP_BLOB)" ]]
 }
 
+@test "checking if deleted blob was removed from memory" {
+  run GET "$CACHE/get?bucket=$BUCKET&key=folder/subfolder/blob"
+  [[ "$status" -eq 0 ]]
+  [[ "$output" == "404" ]]
+}
+
 # Invalidate
 
 @test "invalidating blob from memory" {

--- a/tests/s3.bats
+++ b/tests/s3.bats
@@ -29,6 +29,20 @@ load helpers.sh
   [[ "$status" -eq 0 ]]
 }
 
+# Get
+
+@test "getting blob from test bucket" {
+  run GET "$CACHE/get?bucket=$BUCKET&key=blob"
+  [[ "$status" -eq 0 ]]
+  [[ "$output" == "200" ]]
+  [[ "$(SHA $DIR/blob)" == "$(SHA $TMP_BLOB)" ]]
+
+  run GET "$CACHE/get?bucket=$BUCKET&key=folder/subfolder/blob"
+  [[ "$status" -eq 0 ]]
+  [[ "$output" == "200" ]]
+  [[ "$(SHA $DIR/blob)" == "$(SHA $TMP_BLOB)" ]]
+}
+
 # Delete
 
 @test "deleting blob from test bucket" {
@@ -47,15 +61,6 @@ load helpers.sh
 
   run AWS s3 ls s3://$BUCKET//folder/subfolder
   [ "$status" -eq 1 ]
-}
-
-# Get
-
-@test "getting blob from test bucket" {
-  run GET "$CACHE/get?bucket=$BUCKET&key=blob"
-  [[ "$status" -eq 0 ]]
-  [[ "$output" == "200" ]]
-  [[ "$(SHA $DIR/blob)" == "$(SHA $TMP_BLOB)" ]]
 }
 
 # Prewarm


### PR DESCRIPTION
Uploads and deletes should invalidate the in-memory key so we don't serve stale data.