### PR TITLE
Add gin json logs and metrics middleware

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -1,5 +1,5 @@
-// Copyright 2020 Adrian Chifor, Marshall Wace
-// SPDX-FileCopyrightText: 2020 Marshall Wace <opensource@mwam.com>
+// Copyright 2021 Adrian Chifor, Marshall Wace
+// SPDX-FileCopyrightText: 2021 Marshall Wace <opensource@mwam.com>
 // SPDX-License-Identifier: GPL-3.0-only
 
 package main

--- a/main.go
+++ b/main.go
@@ -1,5 +1,5 @@
-// Copyright 2020 Adrian Chifor, Marshall Wace
-// SPDX-FileCopyrightText: 2020 Marshall Wace <opensource@mwam.com>
+// Copyright 2021 Adrian Chifor, Marshall Wace
+// SPDX-FileCopyrightText: 2021 Marshall Wace <opensource@mwam.com>
 // SPDX-License-Identifier: GPL-3.0-only
 
 package main
@@ -17,7 +17,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-const version string = "0.12.0"
+const version string = "0.13.0"
 
 var (
 	host               string
@@ -89,17 +89,20 @@ func runServer() {
 	quit := make(chan os.Signal, 1)
 	signal.Notify(quit, syscall.SIGINT, syscall.SIGTERM)
 
+	router := gin.Default()
+
 	listenAddr := fmt.Sprintf("127.0.0.1:%d", port)
 	if os.Getenv("GIN_MODE") == "release" {
 		listenAddr = fmt.Sprintf("0.0.0.0:%d", port)
 		log.SetFormatter(&log.JSONFormatter{})
+		router.Use(jsonLogMiddleware())
 	} else {
 		log.SetFormatter(&log.TextFormatter{
 			FullTimestamp: true,
 		})
 	}
 
-	router := gin.Default()
+	router.Use(httpMetricsMiddleware())
 	router.MaxMultipartMemory = maxMultipartMemory << 20
 	router.POST("/upload", s3Upload)
 	router.DELETE("/delete", s3Delete)

--- a/metrics.go
+++ b/metrics.go
@@ -1,5 +1,5 @@
-// Copyright 2020 Adrian Chifor, Marshall Wace
-// SPDX-FileCopyrightText: 2020 Marshall Wace <opensource@mwam.com>
+// Copyright 2021 Adrian Chifor, Marshall Wace
+// SPDX-FileCopyrightText: 2021 Marshall Wace <opensource@mwam.com>
 // SPDX-License-Identifier: GPL-3.0-only
 
 package main
@@ -19,6 +19,8 @@ import (
 
 var (
 	metricsPort                       int
+	httpRequestsMetric                *prometheus.CounterVec
+	httpRequestsLatencyMetric         *prometheus.GaugeVec
 	groupGetsMetric                   prometheus.Gauge
 	groupCacheHitsMetric              prometheus.Gauge
 	groupPeersGetHighestLatencyMetric prometheus.Gauge
@@ -37,6 +39,14 @@ var (
 )
 
 func initMetrics() {
+	httpRequestsMetric = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "cachenator_http_requests_total",
+		Help: "Total number of HTTP requests",
+	}, []string{"method", "path", "status"})
+	httpRequestsLatencyMetric = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "cachenator_http_requests_latency",
+		Help: "HTTP requests latency",
+	}, []string{"method", "path", "status"})
 	groupGetsMetric = promauto.NewGauge(prometheus.GaugeOpts{
 		Name: "cachenator_gets_total",
 		Help: "Total number of get requests",

--- a/s3.go
+++ b/s3.go
@@ -1,5 +1,5 @@
-// Copyright 2020 Adrian Chifor, Marshall Wace
-// SPDX-FileCopyrightText: 2020 Marshall Wace <opensource@mwam.com>
+// Copyright 2021 Adrian Chifor, Marshall Wace
+// SPDX-FileCopyrightText: 2021 Marshall Wace <opensource@mwam.com>
 // SPDX-License-Identifier: GPL-3.0-only
 
 package main


### PR DESCRIPTION
Gin HTTP middleware for JSON logging on release version, and Prometheus middleware to instrument the HTTP handlers with 2 new metrics `cachenator_http_requests_total` and `cachenator_http_requests_latency`