### PR TITLE
Ignore /_groupcache in path label on metrics middleware

### DIFF
--- a/main.go
+++ b/main.go
@@ -17,7 +17,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-const version string = "0.13.0"
+const version string = "0.13.1"
 
 var (
 	host               string

--- a/utils.go
+++ b/utils.go
@@ -75,6 +75,10 @@ func jsonLogMiddleware() gin.HandlerFunc {
 
 func httpMetricsMiddleware() gin.HandlerFunc {
 	return func(c *gin.Context) {
+		if strings.HasPrefix(c.Request.RequestURI, "/_groupcache") {
+			return
+		}
+
 		start := time.Now()
 		c.Next()
 		duration := getDurationInMillseconds(start)


### PR DESCRIPTION
This is creating duplicate metrics for the same paths